### PR TITLE
fix(ci): set AccessMode to many

### DIFF
--- a/.github/auto-deploy-values.yaml
+++ b/.github/auto-deploy-values.yaml
@@ -51,7 +51,7 @@ persistence:
         path: "/data"
       claim:
         size: "20Gi"
-        accessMode: "ReadWriteOnce"
+        accessMode: "ReadWriteMany"
 
 securityContext:
   fsGroup: 1000


### PR DESCRIPTION
set the AccessMode for the pvc to many in order to prevent access errors when new dploy gets moved to new node
