### PR TITLE
fix: remove reference from speaches

### DIFF
--- a/mine_frontend/templates/mine_frontend/partials/speaches_nekrologes.html
+++ b/mine_frontend/templates/mine_frontend/partials/speaches_nekrologes.html
@@ -6,9 +6,6 @@
             <li class="fw-normal pb-1">
                 {{ speach.obj }}
                 {% if speach.obj.datum %}({{ speach.obj.datum_date_sort|date:"Y" }}){% endif %}
-                {% if speach.references %}
-                    {% include 'mine_frontend/partials/tooltip_info.html' with text=speach.references %}
-                {% endif %}
             </li>
         {% endfor %}
     </ul>


### PR DESCRIPTION
currently the reference shows a zotero link with the pages of the
almanach. We change that to show the actual pages as soon as scanning
etc is finished.

see #55
