### PR TITLE
chore: switch back to main for base container

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,5 +11,3 @@ jobs:
   deploy:
     uses: acdh-oeaw/prosnet-workflows/.github/workflows/deploy-apis-instance.yml@v0.6.0
     secrets: inherit
-    with:
-      apis-base-container-ref: "birger/uv"


### PR DESCRIPTION
`uv` merged into main