### PR TITLE
chore: bump deploy workflow; remove tzdata again

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,5 +9,5 @@ on:
 
 jobs:
   deploy:
-    uses: acdh-oeaw/prosnet-workflows/.github/workflows/deploy-apis-instance.yml@v0.6.0
+    uses: acdh-oeaw/prosnet-workflows/.github/workflows/deploy-apis-instance.yml@v0.7.1
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ dependencies = [
     "django-auditlog==3.3.0",
     "imgproxy>=1.0.0",
     "gunicorn>=26.0.0",
-    "tzdata>=2025.1",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -759,7 +759,6 @@ dependencies = [
     { name = "httpx" },
     { name = "imgproxy" },
     { name = "psycopg2-binary" },
-    { name = "tzdata" },
 ]
 
 [package.dev-dependencies]
@@ -790,7 +789,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "imgproxy", specifier = ">=1.0.0" },
     { name = "psycopg2-binary", specifier = ">=2.9,<3.0" },
-    { name = "tzdata", specifier = ">=2025.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
tzdata is not needed anymore as the base image includes it